### PR TITLE
Unify action workflow

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           - {ROS_DISTRO: kinetic}
           - {ROS_DISTRO: melodic}
-          - {ROS_DISTRO: noetic, BEFORE_SETUP_TARGET_WORKSPACE: 'apt-get install python-is-python3'}
+          - {ROS_DISTRO: noetic, AFTER_SETUP_ROSDEP: 'apt-get install python-is-python3'}
     name: ${{matrix.env.ROS_DISTRO}}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
use AFTER_SETUP_ROSDEP because BEFORE_SETUP_TARGET_WORKSPACE is to late