### PR TITLE
[FAILS] Feature/manual test execution noetic

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           - {ROS_DISTRO: kinetic}
           - {ROS_DISTRO: melodic}
-          - {ROS_DISTRO: noetic, BEFORE_BUILD_TARGET_WORKSPACE: apt install -y python3-osrf-pycommon, BUILDER: catkin_tools} # manual installation of osrf-pycomm is a workaround for https://github.com/catkin/catkin_tools/issues/594#issuecomment-688149976
+          - {ROS_DISTRO: noetic, BEFORE_BUILD_TARGET_WORKSPACE: apt install -y python3-osrf-pycommon} # manual installation of osrf-pycomm is a workaround for https://github.com/catkin/catkin_tools/issues/594#issuecomment-688149976
     name: ${{matrix.env.ROS_DISTRO}}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 30
     env:
       ADDITIONAL_DEBS: apt-utils git-core openssh-client openssh-server curl
-      AFTER_INIT: mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && ssh-keyscan github.com >> ~/.ssh/known_hosts && git config --global url."https://token:${{secrets.GITHUBPAT}}@github.com/".insteadOf "https://github.com/" && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install git-lfs -y && cd $HOME && git lfs install && cd -
+      AFTER_INIT: mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && ssh-keyscan github.com >> ~/.ssh/known_hosts && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install git-lfs -y && cd $HOME && git lfs install && cd -
       CATKIN_LINT: pedantic
       NOT_TEST_DOWNSTREAM: true
       PYLINT_ARGS: "--output-format=parseable --errors-only --ignored-modules=catkin_pkg.python_setup,lxml.etree,lxml.builder,matplotlib,numpy,progressbar,rospkg,six.moves.http_client,tf2_ros,yaml"
@@ -27,7 +27,7 @@ jobs:
         env:
           - {ROS_DISTRO: kinetic}
           - {ROS_DISTRO: melodic}
-          - {ROS_DISTRO: noetic, BEFORE_RUN_TARGET_TEST: apt install -y python3-osrf-pycommon} # manual installation of osrf-pycomm is a workaround for https://github.com/catkin/catkin_tools/issues/594#issuecomment-688149976
+          - {ROS_DISTRO: noetic, BEFORE_BUILD_TARGET_WORKSPACE: apt install -y python3-osrf-pycommon, BUILDER: catkin_tools} # manual installation of osrf-pycomm is a workaround for https://github.com/catkin/catkin_tools/issues/594#issuecomment-688149976
     name: ${{matrix.env.ROS_DISTRO}}
     runs-on: ubuntu-latest
     steps:

--- a/atf_test/CMakeLists.txt
+++ b/atf_test/CMakeLists.txt
@@ -23,7 +23,8 @@ install(DIRECTORY atf launch test
 ## Testing ##
 #############
 if(CATKIN_ENABLE_TESTING)
-  find_package(atf_core rostest REQUIRED)
+  find_package(atf_core REQUIRED)
+  find_package(rostest REQUIRED)
   add_rostest(test/manual_execution.test)
 endif()
 

--- a/atf_test/CMakeLists.txt
+++ b/atf_test/CMakeLists.txt
@@ -22,13 +22,13 @@ install(DIRECTORY atf launch test
 #############
 ## Testing ##
 #############
-#if(CATKIN_ENABLE_TESTING)
-#  find_package(rostest REQUIRED)
-#  add_rostest(test/manual_execution.test)
-#endif()
-
 if(CATKIN_ENABLE_TESTING)
-  find_package(atf_core REQUIRED)
-  atf_test(atf/test_generation_config.yaml)
-  atf_test(atf/test_generation_config_extended.yaml False)
+  find_package(atf_core rostest REQUIRED)
+  add_rostest(test/manual_execution.test)
 endif()
+
+#if(CATKIN_ENABLE_TESTING)
+#  find_package(atf_core REQUIRED)
+#  atf_test(atf/test_generation_config.yaml)
+#  atf_test(atf/test_generation_config_extended.yaml False)
+#endif()

--- a/atf_test/CMakeLists.txt
+++ b/atf_test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(atf_test)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS rostest)
 
 catkin_package()
 
@@ -24,7 +24,6 @@ install(DIRECTORY atf launch test
 #############
 if(CATKIN_ENABLE_TESTING)
   find_package(atf_core REQUIRED)
-  find_package(rostest REQUIRED)
   add_rostest(test/manual_execution.test)
 endif()
 

--- a/atf_test/package.xml
+++ b/atf_test/package.xml
@@ -12,6 +12,8 @@
 
     <buildtool_depend>catkin</buildtool_depend>
 
+    <build_depend>rostest</build_depend>
+
     <exec_depend>atf_core</exec_depend>
     <exec_depend>atf_test_tools</exec_depend>
     <exec_depend>rospy</exec_depend>
@@ -19,6 +21,5 @@
     <exec_depend>tf2_ros</exec_depend>
 
     <test_depend>atf_core</test_depend>
-    <test_depend>rostest</test_depend>
 
 </package>

--- a/atf_test/package.xml
+++ b/atf_test/package.xml
@@ -12,7 +12,7 @@
 
     <buildtool_depend>catkin</buildtool_depend>
 
-    <build_depend>rostest</build_depend>
+    <exec_depend>rostest</exec_depend>
 
     <exec_depend>atf_core</exec_depend>
     <exec_depend>atf_test_tools</exec_depend>
@@ -21,5 +21,6 @@
     <exec_depend>tf2_ros</exec_depend>
 
     <test_depend>atf_core</test_depend>
+    <test_depend>rostest</test_depend>
 
 </package>


### PR DESCRIPTION
fails in noetic due to colcon builder

```
Function 'run_target_test' returned with code '0' after 0 min 7 sec
build/atf_test/Testing/20210131-2118/Test.xml: 1 test, 0 errors, 1 failure, 0 skipped
- _ctest_atf_test_rostest_test_manual_execution.test
  <<< failure message
    ERROR: No workspace found containing '/root/target_ws/build/atf_test/devel'
    ERROR: No workspace found containing '/root/target_ws/build/atf_test/devel'
    ERROR: No workspace found containing '/root/target_ws/install/atf_core'
    ERROR: No workspace found containing '/root/target_ws/install/atf_recorder_plugins'
    ERROR: No workspace found containing '/root/target_ws/install/atf_metrics'
    ERROR: No workspace found containing '/root/target_ws/install/atf_test_tools'
    ERROR: No workspace found containing '/root/target_ws/install/atf_msgs'
    ERROR: No workspace found containing '/opt/ros/noetic'
    ... logging to /root/.ros/log/rostest-56ea328b699a-7856.log
```