### PR TITLE
Report about no transforms found when a TF metric fails for that reason.

### DIFF
--- a/atf_metrics/src/atf_metrics/calculate_tf_acceleration_translation.py
+++ b/atf_metrics/src/atf_metrics/calculate_tf_acceleration_translation.py
@@ -188,7 +188,8 @@ class CalculateTfAccelerationTranslation:
         if len(self.series) == 0:
             # let the analyzer know that this test failed
             metric_result.groundtruth.result = Groundtruth.FAILED
-            metric_result.groundtruth.error_message = "testblock %s stopped without result"%self.testblock_name
+            metric_result.groundtruth.error_message = "testblock {} stopped without result. " \
+                "No transforms found between {} & {}".format(self.testblock_name, self.root_frame, self.measured_frame)
             return metric_result
 
         # at this point we're sure that any result is available

--- a/atf_metrics/src/atf_metrics/calculate_tf_distance_rotation.py
+++ b/atf_metrics/src/atf_metrics/calculate_tf_distance_rotation.py
@@ -166,7 +166,8 @@ class CalculateTfDistanceRotation:
         if len(self.series) == 0:
             # let the analyzer know that this test failed
             metric_result.groundtruth.result = Groundtruth.FAILED
-            metric_result.groundtruth.error_message = "testblock %s stopped without result"%self.testblock_name
+            metric_result.groundtruth.error_message = "testblock {} stopped without result. " \
+                "No transforms found between {} & {}".format(self.testblock_name, self.root_frame, self.measured_frame)
             return metric_result
 
         # at this point we're sure that any result is available

--- a/atf_metrics/src/atf_metrics/calculate_tf_distance_translation.py
+++ b/atf_metrics/src/atf_metrics/calculate_tf_distance_translation.py
@@ -161,7 +161,8 @@ class CalculateTfDistanceTranslation:
         if len(self.series) == 0:
             # let the analyzer know that this test failed
             metric_result.groundtruth.result = Groundtruth.FAILED
-            metric_result.groundtruth.error_message = "testblock %s stopped without result"%self.testblock_name
+            metric_result.groundtruth.error_message = "testblock {} stopped without result. " \
+                "No transforms found between {} & {}".format(self.testblock_name, self.root_frame, self.measured_frame)
             return metric_result
 
         # at this point we're sure that any result is available

--- a/atf_metrics/src/atf_metrics/calculate_tf_jerk_translation.py
+++ b/atf_metrics/src/atf_metrics/calculate_tf_jerk_translation.py
@@ -200,7 +200,10 @@ class CalculateTfJerkTranslation:
         if len(self.series) == 0:
             # let the analyzer know that this test failed
             metric_result.groundtruth.result = Groundtruth.FAILED
-            metric_result.groundtruth.error_message = "testblock %s stopped without result"%self.testblock_name
+            metric_result.groundtruth.error_message = "testblock {} stopped without result. " \
+                                                      "No transforms found between {} & {}".format(self.testblock_name,
+                                                                                                   self.root_frame,
+                                                                                                   self.measured_frame)
             return metric_result
 
         # at this point we're sure that any result is available

--- a/atf_metrics/src/atf_metrics/calculate_tf_length_rotation.py
+++ b/atf_metrics/src/atf_metrics/calculate_tf_length_rotation.py
@@ -177,7 +177,10 @@ class CalculateTfLengthRotation:
         if len(self.series) == 0:
             # let the analyzer know that this test failed
             metric_result.groundtruth.result = Groundtruth.FAILED
-            metric_result.groundtruth.error_message = "testblock %s stopped without result"%self.testblock_name
+            metric_result.groundtruth.error_message = "testblock {} stopped without result. " \
+                                                      "No transforms found between {} & {}".format(self.testblock_name,
+                                                                                                   self.root_frame,
+                                                                                                   self.measured_frame)
             return metric_result
 
         # at this point we're sure that any result is available

--- a/atf_metrics/src/atf_metrics/calculate_tf_length_translation.py
+++ b/atf_metrics/src/atf_metrics/calculate_tf_length_translation.py
@@ -173,7 +173,10 @@ class CalculateTfLengthTranslation:
         if len(self.series) == 0:
             # let the analyzer know that this test failed
             metric_result.groundtruth.result = Groundtruth.FAILED
-            metric_result.groundtruth.error_message = "testblock %s stopped without result"%self.testblock_name
+            metric_result.groundtruth.error_message = "testblock {} stopped without result. " \
+                                                      "No transforms found between {} & {}".format(self.testblock_name,
+                                                                                                   self.root_frame,
+                                                                                                   self.measured_frame)
             return metric_result
 
         # at this point we're sure that any result is available

--- a/atf_metrics/src/atf_metrics/calculate_tf_velocity_translation.py
+++ b/atf_metrics/src/atf_metrics/calculate_tf_velocity_translation.py
@@ -176,7 +176,10 @@ class CalculateTfVelocityTranslation:
         if len(self.series) == 0:
             # let the analyzer know that this test failed
             metric_result.groundtruth.result = Groundtruth.FAILED
-            metric_result.groundtruth.error_message = "testblock %s stopped without result"%self.testblock_name
+            metric_result.groundtruth.error_message = "testblock {} stopped without result. " \
+                                                      "No transforms found between {} & {}".format(self.testblock_name,
+                                                                                                   self.root_frame,
+                                                                                                   self.measured_frame)
             return metric_result
 
         # at this point we're sure that any result is available


### PR DESCRIPTION
The generic "Stopped without result" pointed me to a different, wrong direction.

My issue was that I had a wrong transform with non-existent frame but I wrongly interpreted that as the test did not succeed or did not get a result set. This clearer error message might have helped. 